### PR TITLE
Add and fix Lean

### DIFF
--- a/Checker/Base.lean
+++ b/Checker/Base.lean
@@ -4,9 +4,6 @@
 -- Equality
 -- -------
 
-inductive Base.Equal : {t: Type u} -> (a: t) -> (b :t) -> Type u where
-  | refl : Equal a a
-
 inductive Base.Bool where
   | tt : Bool
   | ff : Bool

--- a/Checker/nat_exp.lean
+++ b/Checker/nat_exp.lean
@@ -1,2 +1,2 @@
 def Size : Base.Nat := Base.N1
-def Main : Base.Equal (Base.is_even (Base.exp Base.N2 Size)) Base.Bool.tt := Base.Equal.refl
+def Main : Eq (Base.is_even (Base.exp Base.N2 Size)) Base.Bool.tt := by rfl

--- a/Checker/nat_exp_church.lean
+++ b/Checker/nat_exp_church.lean
@@ -1,2 +1,6 @@
+-- Lean tries to avoid doing long kernel computation to stay interactive
+set_option maxRecDepth 1000000000000
+set_option maxHeartbeats 1000000000000
+
 def Size : Base.Church.Nat := Base.Church.N1
-def Main : Base.Equal (Base.Church.is_even (Base.Church.exp Base.Church.N2 Size)) Base.Church.true := Base.Equal.refl
+def Main : Eq (Base.Church.is_even (Base.Church.exp Base.Church.N2 Size)) Base.Church.true := by rfl

--- a/Checker/tree_fold.lean
+++ b/Checker/tree_fold.lean
@@ -1,2 +1,2 @@
 def Size : Base.Nat := Base.N1
-def Main : Base.Equal (Base.force_tree (Base.full_tree Size)) Base.Bool.tt := Base.Equal.refl
+def Main : Eq (Base.force_tree (Base.full_tree Size)) Base.Bool.tt := by rfl

--- a/Checker/tree_fold_church.lean
+++ b/Checker/tree_fold_church.lean
@@ -1,2 +1,6 @@
+-- Lean tries to avoid doing long kernel computation to stay interactive
+set_option maxRecDepth 1000000000000
+set_option maxHeartbeats 1000000000000
+
 def Size : Base.Church.Nat := Base.Church.N1
-def Main : Base.Equal (Base.Church.force_tree (Base.Church.full_tree Size)) Base.Church.true := Base.Equal.refl
+def Main : Eq (Base.Church.force_tree (Base.Church.full_tree Size)) Base.Church.true := by rfl

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Replicating
 To replicate these benchmarks, just run:
 
 ```
-node run benchmark.js
+ulimit -s unlimited # give unlimited stack space
+node benchmark.js
 ```
 
 For specific commands, check the contents of [benchmark.js](benchmark.js).

--- a/Runtime/composition.lean
+++ b/Runtime/composition.lean
@@ -1,0 +1,10 @@
+
+partial def comp (p : UInt64) (f : UInt64 → UInt64) (n : UInt64) : UInt64 :=
+  if p == 0 then
+    f n
+  else
+    comp (p  - 1) (fun k => f (f k)) n
+
+def main (xs : List String) : IO Unit := do
+  let n := UInt64.ofNat $ String.toNat! xs.head!
+  IO.print $ comp n (fun x => x) 0

--- a/Runtime/list_fold.lean
+++ b/Runtime/list_fold.lean
@@ -1,0 +1,29 @@
+namespace Example
+
+inductive List (α : Type u) where
+  | nil : List α
+  | cons (head : α) (tail : List α) : List α
+
+namespace List
+
+def foldr (f : α → β → β) (init : β) : List α → β
+  | .nil => init
+  | .cons a l => f a (foldr f init l)
+
+-- Partial is just so I don't have to do a recursion proof, it actually inhibits opts
+-- in certain special cases
+partial def range (final : UInt64) (xs : List UInt64 := nil) : List UInt64 :=
+  if final == 0 then
+    xs
+  else
+    let m := final - 1
+    range m (cons m xs)
+
+end List
+end Example
+
+def main (xs : List String) : IO Unit := do
+  let n := UInt64.ofNat $ String.toNat! xs.head!
+  let size := 1000000 * n
+  let list := Example.List.range size .nil
+  IO.print $ list.foldr (· + ·) 0

--- a/Runtime/quicksort.lean
+++ b/Runtime/quicksort.lean
@@ -1,0 +1,68 @@
+namespace Example
+
+inductive List (α : Type u) where
+| nil : List α
+| cons (head : α) (tail : List α) : List α
+deriving Inhabited
+
+inductive Tree (α : Type u) where
+| concat (l r : Tree α) : Tree α
+| single (d : α) : Tree α
+| empty : Tree α
+deriving Inhabited
+
+namespace Tree
+
+def sum : Tree UInt32 → UInt32
+  | empty => 0
+  | single a => a
+  | concat a b => sum a + sum b
+
+end Tree
+
+
+namespace List
+
+partial def randoms (seed : UInt32) (size : UInt32) : List UInt32 :=
+  if size == 0 then
+    nil
+  else
+    cons seed (randoms (seed * 1664525 + 1013904223) (size - 1))
+
+
+mutual
+
+  partial def qsort (p s : UInt32) (xs : List UInt32) : Tree UInt32:=
+    match xs with
+    | nil => .empty
+    | .cons x nil => .single x
+    | .cons x xs =>
+      split p s (cons x xs) nil nil
+
+  partial def split (p s : UInt32) (xs min max : List UInt32) : Tree UInt32 :=
+    match xs with
+    | nil =>
+      let s' := s >>> 1
+      let min' := qsort (p - s') s' min
+      let max' := qsort (p + s') s' max
+      .concat min' max'
+    | cons x xs =>
+      place p s (p < x) x xs min max
+
+  partial def place (p s : UInt32) (b : Bool) (x : UInt32) (xs min max : List UInt32) : Tree UInt32 :=
+    match b with
+    | false => split p s xs (cons x min) max
+    | true => split p s xs min (cons x max)
+
+end 
+
+end List
+
+end Example
+
+def pivot : UInt32 := 2147483648
+
+def main (xs : List String) : IO Unit := do
+  let n := UInt32.ofNat $ String.toNat! xs.head!
+  let list := Example.List.randoms 1 (100000 * n)
+  IO.print $ (list.qsort pivot pivot).sum

--- a/Runtime/tree_fold.lean
+++ b/Runtime/tree_fold.lean
@@ -1,0 +1,23 @@
+inductive Tree where
+| node (l r : Tree) : Tree
+| leaf (w : UInt32) : Tree
+deriving Inhabited
+
+
+namespace Tree
+
+partial def gen (val : UInt32) : Tree :=
+  if val == 0 then
+    .leaf 1
+  else
+    .node (gen (val - 1)) (gen (val - 1))
+
+def sum : Tree → UInt32
+  | .leaf _ => 1
+  | .node l r => sum l + sum r
+
+end Tree
+
+def main (xs : List String) : IO Unit := do
+  let n := UInt32.ofNat $ String.toNat! xs.head!
+  IO.print $ (Tree.gen n).sum

--- a/benchmark.js
+++ b/benchmark.js
@@ -20,6 +20,7 @@ let allowed_tests = {
   vector: true,
   quicksort: true,
   composition: true,
+  tree_fold: true,
 }
 
 var langs = {
@@ -183,9 +184,11 @@ var langs = {
     checker: {
       tasks: {
         nat_exp: [10,14],
-        nat_exp_church: [16,24],
+        // Lean has not optimized kernel computation so this goes exponential quick
+        nat_exp_church: [16,18],
         tree_fold: [16,24],
-        tree_fold_church: [16,24],
+        // Lean has not optimized kernel computation so this goes exponential quick
+        tree_fold_church: [16,18],
         vector: [1, 4],
       },
       build: (task) => {
@@ -202,7 +205,28 @@ var langs = {
       },
       clean: () => {
       },
-    }
+    },
+    runtime: {
+      tasks: {
+        list_fold: [1,64],
+        tree_fold: [26,32],
+        quicksort: [0, 15],
+        composition: [10, 32],
+      },
+      build: (task) => {
+        save("main.lean", load("Runtime/"+task+".lean"));
+        exec("lean main.lean -c main.c");
+        exec("leanc -o main.bin -O3 -DNDEBUG main.c");
+      },
+      bench: (task, size) => {
+        return bench("./main.bin " + size);
+      },
+      clean: () => {
+        rm("main.lean");
+        rm("main.c");
+        rm("main.bin");
+      },
+    },
   },
 };
 


### PR DESCRIPTION
This PR:
- Uses built-in equality of Lean for type checker things
- Ramps up the resources Lean is allowed to consume for type checking. Usually we try to avoid long type checks because we want the system to always stay interactive
- Adds a port of all the runtime benchmarks